### PR TITLE
resetGUI fix

### DIFF
--- a/MVC/view/GUI.py
+++ b/MVC/view/GUI.py
@@ -642,7 +642,6 @@ Each puzzle is based off of a pangram, a 7 to 15 letter word that contains 7 uni
                 self.displayHighScores()
                 # Reset the GUI
                 self.resetGUI()
-                self.controller.controllerNewGame()
             else:
                 confirm = messagebox.askyesno("Give up", "Are you sure you want to give up?")
                 if confirm:
@@ -661,7 +660,6 @@ Each puzzle is based off of a pangram, a 7 to 15 letter word that contains 7 uni
                     self.displayHighScores()
                     # Reset the GUI
                     self.resetGUI()
-                    self.controller.controllerNewGame()
                 else:
                     return
 

--- a/MVC/view/GUI.py
+++ b/MVC/view/GUI.py
@@ -605,7 +605,7 @@ Each puzzle is based off of a pangram, a 7 to 15 letter word that contains 7 uni
         self.clearInput()
         self.clearListbox()
         self.hexagonLetters.clear()
-        self.points.set(0)
+        self.points.set("")
         self.rank.set("")
         self.e.unbind("<Return>")
         self.canvas.delete("all")


### PR DESCRIPTION
I was using darkmode on Mac and never noticed that when giveUp is used in the GUI it reset everything but the score, which got set back to "0". Super simple fix, sorry about that